### PR TITLE
Feature/BDN-1147: Add callback logging for ad lifecycle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - BDN-1139 Viewability improvements
 - BDN-1140 Fix demand adapter delegates - banner adapters no longer call fullscreen delegate callbacks
 - BDN-1150 Migrated workflows to new podspec push flow
+- BDN-1147 Add callback logging to Sandbox demo screens for ad lifecycle events
 
 # Release 0.14.0
 

--- a/Sandbox/Sandbox/Banner/Advanced/AdvancedBannerSettingsView.swift
+++ b/Sandbox/Sandbox/Banner/Advanced/AdvancedBannerSettingsView.swift
@@ -121,6 +121,8 @@ struct AdvancedBannerSettings: View {
                     Button(action: bannerProviderReference.provider.hide) {
                         Text("Hide")
                     }
+
+                    NavigationLink("Events", destination: AdEventsList(events: bannerProviderReference.events))
                 }
             }
             .listStyle(.automatic)

--- a/Sandbox/Sandbox/Shared/Advertising/BannerProviderReference.swift
+++ b/Sandbox/Sandbox/Shared/Advertising/BannerProviderReference.swift
@@ -46,12 +46,27 @@ final class BannerProviderReference: NSObject, AdObjectDelegate, ObservableObjec
 
     @Published var isShown: Bool = false
     @Published var isLoaded: Bool = false
+    @Published var events: [AdEventModel] = []
 
     private(set) lazy var provider: BannerProvider = {
         let provider = BannerProvider(auctionKey: nil)
         provider.delegate = self
         return provider
     }()
+
+    private func send(event title: String, detail: String, bage: String, color: Color) {
+        let event = AdEventModel(
+            date: Date(),
+            adType: .banner,
+            title: title,
+            subtitle: detail,
+            bage: bage,
+            color: color
+        )
+        withAnimation { [unowned self] in
+            self.events.append(event)
+        }
+    }
 
     func updatePosition() {
         switch positioningStyle {
@@ -67,56 +82,57 @@ final class BannerProviderReference: NSObject, AdObjectDelegate, ObservableObjec
     }
 
     func adObject(_ adObject: AdObject, didLoadAd ad: Ad, auctionInfo: AuctionInfo) {
-        print("[Banner Provider Reference] Did load ad \(ad)")
-
+        Logger.debug("[Banner] [Callback] Did load ad")
         Logger.debug("[Public API] [AUCTION] [LOAD]: \(auctionInfo.description ?? "")")
-
         Logger.debug("[Public API] [AD] [LOAD]: \(ad.description() ?? "")")
-
+        send(event: "Bidon did load ad", detail: ad.text, bage: "star.fill", color: .accentColor)
         withAnimation { [unowned self] in
             self.isLoaded = true
         }
     }
 
     func adObject(_ adObject: AdObject, didFailToLoadAd error: Error, auctionInfo: AuctionInfo) {
-        print("[Banner Provider Reference] Did fail to load ad with error: \(error)")
-
+        Logger.debug("[Banner] [Callback] Did fail to load ad with error: \(error.localizedDescription)")
         Logger.debug("[Public API] [AUCTION] [LOAD] [ERROR]: \(auctionInfo.description ?? ""), error: \(error)")
-
+        send(event: "Bidon did fail to load ad", detail: error.localizedDescription, bage: "star.fill", color: .red)
         withAnimation { [unowned self] in
             self.isLoaded = false
         }
     }
 
     func adObject(_ adObject: AdObject, didFailToPresentAd error: Error) {
-        print("[Banner Provider Reference] Did fail to present ad with error: \(error)")
-
+        Logger.debug("[Banner] [Callback] Did fail to present ad with error: \(error.localizedDescription)")
+        send(event: "Bidon did fail to present ad", detail: error.localizedDescription, bage: "star.fill", color: .red)
         withAnimation { [unowned self] in
             self.isShown = false
         }
     }
 
     func adObject(_ adObject: AdObject, didRecordImpression ad: Ad) {
-        print("[Banner Provider Reference] Did record impression for ad \(ad)")
-
+        Logger.debug("[Banner] [Callback] Did record impression")
         Logger.debug("[Public API] [AD] [SHOW]: \(ad.description() ?? "")")
-
+        send(event: "Bidon did record impression", detail: ad.text, bage: "flag.fill", color: .accentColor)
         withAnimation { [unowned self] in
             self.isShown = true
         }
     }
 
     func adObject(_ adObject: AdObject, didExpireAd ad: Ad) {
-        print("[Banner Provider Reference] Did expire ad \(ad)")
+        Logger.debug("[Banner] [Callback] Did expire ad")
+        send(event: "Bidon expire ad", detail: ad.text, bage: "star.fill", color: .secondary)
+        withAnimation { [unowned self] in
+            self.isLoaded = false
+        }
     }
 
     func adObject(_ adObject: AdObject, didRecordClick ad: Ad) {
-        print("[Banner Provider Reference] Did record click for ad \(ad)")
+        Logger.debug("[Banner] [Callback] Did record click")
+        send(event: "Bidon did record click", detail: ad.text, bage: "flag.fill", color: .accentColor)
     }
 
     func adObject(_ adObject: AdObject, didPay revenue: AdRevenue, ad: Ad) {
+        Logger.debug("[Banner] [Callback] Did pay revenue: \(revenue.revenue.pretty)")
         Logger.debug("[Public API] [AD] [REVENUE]: \(ad.description(with: revenue) ?? "")")
-
-        print("[Banner Provider Reference] Did pay revenue \(revenue) for ad \(ad)")
+        send(event: "Bidon did pay revenue \(revenue.revenue.pretty)", detail: ad.text, bage: "cart.fill", color: .primary)
     }
 }

--- a/Sandbox/Sandbox/Shared/Advertising/Base/BaseAdWrapper.swift
+++ b/Sandbox/Sandbox/Shared/Advertising/Base/BaseAdWrapper.swift
@@ -20,6 +20,7 @@ class BaseAdWrapper: NSObject, AdWrapper {
 
 extension BaseAdWrapper: Bidon.AdObjectDelegate {
     func adObject(_ adObject: Bidon.AdObject, didLoadAd ad: Bidon.Ad, auctionInfo: AuctionInfo) {
+        Logger.debug("\(adType.title) [Callback] Did load ad")
         send(
             event: "Bidon did load ad",
             detail: ad.text,
@@ -29,11 +30,11 @@ extension BaseAdWrapper: Bidon.AdObjectDelegate {
         adSubject.send(ad)
 
         Logger.debug("[Public API] [AUCTION] [LOAD]: \(auctionInfo.description ?? "")")
-
         Logger.debug("[Public API] [AD] [LOAD]: \(ad.description() ?? "")")
     }
 
     func adObject(_ adObject: Bidon.AdObject, didFailToLoadAd error: Error, auctionInfo: AuctionInfo) {
+        Logger.debug("\(adType.title) [Callback] Did fail to load ad with error: \(error.localizedDescription)")
         send(
             event: "Bidon did fail to load ad",
             detail: error.localizedDescription,
@@ -46,6 +47,7 @@ extension BaseAdWrapper: Bidon.AdObjectDelegate {
     }
 
     func adObject(_ adObject: Bidon.AdObject, didFailToPresentAd error: Error) {
+        Logger.debug("\(adType.title) [Callback] Did fail to present ad with error: \(error.localizedDescription)")
         send(
             event: "Bidon did fail to present ad",
             detail: error.localizedDescription,
@@ -55,6 +57,7 @@ extension BaseAdWrapper: Bidon.AdObjectDelegate {
     }
 
     func adObject(_ adObject: AdObject, didExpireAd ad: Ad) {
+        Logger.debug("\(adType.title) [Callback] Did expire ad")
         send(
             event: "Bidon expire ad",
             detail: ad.text,
@@ -68,6 +71,7 @@ extension BaseAdWrapper: Bidon.AdObjectDelegate {
         _ adObject: AdObject,
         didRecordImpression ad: Ad
     ) {
+        Logger.debug("\(adType.title) [Callback] Did record impression")
         send(
             event: "Bidon did record impression",
             detail: ad.text,
@@ -83,6 +87,7 @@ extension BaseAdWrapper: Bidon.AdObjectDelegate {
         _ adObject: AdObject,
         didRecordClick ad: Ad
     ) {
+        Logger.debug("\(adType.title) [Callback] Did record click")
         send(
             event: "Bidon did record click",
             detail: ad.text,
@@ -96,6 +101,7 @@ extension BaseAdWrapper: Bidon.AdObjectDelegate {
         didPay revenue: AdRevenue,
         ad: Ad
     ) {
+        Logger.debug("\(adType.title) [Callback] Did pay revenue: \(revenue.revenue.pretty)")
         send(
             event: "Bidon did pay revenue \(revenue.revenue.pretty)",
             detail: ad.text,

--- a/Sandbox/Sandbox/Shared/Advertising/Base/BaseFullscreenAdWrapper.swift
+++ b/Sandbox/Sandbox/Shared/Advertising/Base/BaseFullscreenAdWrapper.swift
@@ -80,6 +80,7 @@ class BaseFullscreenAdWrapper: BaseAdWrapper, FullscreenAdWrapper {
 
 extension BaseFullscreenAdWrapper: Bidon.RewardedAdDelegate {
     func fullscreenAd(_ fullscreenAd: Bidon.FullscreenAdObject, willPresentAd ad: Bidon.Ad) {
+        Logger.debug("\(adType.title) [Callback] Will present ad")
         send(
             event: "Bidon will present ad",
             detail: ad.text,
@@ -89,6 +90,7 @@ extension BaseFullscreenAdWrapper: Bidon.RewardedAdDelegate {
     }
 
     func fullscreenAd(_ fullscreenAd: Bidon.FullscreenAdObject, didDismissAd ad: Bidon.Ad) {
+        Logger.debug("\(adType.title) [Callback] Did dismiss ad")
         send(
             event: "Bidon did dismiss ad",
             detail: ad.text,
@@ -98,6 +100,7 @@ extension BaseFullscreenAdWrapper: Bidon.RewardedAdDelegate {
     }
 
     func rewardedAd(_ rewardedAd: RewardedAdObject, didRewardUser reward: Reward, ad: Ad) {
+        Logger.debug("\(adType.title) [Callback] Did reward user: \(reward.amount) \(reward.label)")
         send(
             event: "Bidon did reward user",
             detail: "Reward is \(reward.amount) \(reward.label)",

--- a/Sandbox/Sandbox/Shared/Advertising/Raw/RawBannerView.swift
+++ b/Sandbox/Sandbox/Shared/Advertising/Raw/RawBannerView.swift
@@ -99,6 +99,7 @@ struct RawBannerView: UIViewRepresentable, AdBannerWrapperView {
 
 extension RawBannerView.Coordinator: Bidon.AdViewDelegate {
     func adView(_ adView: UIView & Bidon.AdView, willPresentScreen ad: Bidon.Ad) {
+        Logger.debug("\(adType.title) [Callback] Will present screen")
         send(
             event: "Bidon will present screen",
             detail: ad.text,
@@ -108,8 +109,9 @@ extension RawBannerView.Coordinator: Bidon.AdViewDelegate {
     }
 
     func adView(_ adView: UIView & Bidon.AdView, didDismissScreen ad: Bidon.Ad) {
+        Logger.debug("\(adType.title) [Callback] Did dismiss screen")
         send(
-            event: "Bidon will dismiss screen",
+            event: "Bidon did dismiss screen",
             detail: ad.text,
             bage: "star.fill",
             color: .accentColor
@@ -117,6 +119,7 @@ extension RawBannerView.Coordinator: Bidon.AdViewDelegate {
     }
 
     func adView(_ adView: UIView & Bidon.AdView, willLeaveApplication ad: Bidon.Ad) {
+        Logger.debug("\(adType.title) [Callback] Will leave application")
         send(
             event: "Bidon will leave application",
             detail: ad.text,

--- a/Sandbox/Sandbox/TestScreens/BannerAdDemoView.swift
+++ b/Sandbox/Sandbox/TestScreens/BannerAdDemoView.swift
@@ -59,29 +59,57 @@ final class BannerAdController: NSObject, ObservableObject, AdViewDelegate {
     // MARK: - AdViewDelegate
 
     func adObject(_ adObject: AdObject, didLoadAd ad: Ad, auctionInfo: AuctionInfo) {
+        Logger.debug("[Banner] [Callback] Did load ad")
         logs.append("✅ Banner Loaded")
         status = "Ad Loaded"
         isAdReady = true
     }
 
     func adObject(_ adObject: AdObject, didFailToLoadAd error: any Error, auctionInfo: AuctionInfo) {
+        Logger.debug("[Banner] [Callback] Did fail to load with error: \(error.localizedDescription)")
         logs.append("❌ Failed to load: \(error.localizedDescription)")
         status = "Failed"
     }
 
+    func adObject(_ adObject: AdObject, didFailToPresentAd error: any Error) {
+        Logger.debug("[Banner] [Callback] Did fail to present with error: \(error.localizedDescription)")
+        logs.append("❌ Failed to present: \(error.localizedDescription)")
+    }
+
+    func adObject(_ adObject: AdObject, didExpireAd ad: Ad) {
+        Logger.debug("[Banner] [Callback] Did expire ad")
+        logs.append("⏰ Ad expired")
+    }
+
     func adObject(_ adObject: AdObject, didRecordImpression ad: Ad) {
+        Logger.debug("[Banner] [Callback] Did record impression")
         logs.append("👁 Impression")
     }
 
     func adObject(_ adObject: AdObject, didRecordClick ad: Ad) {
+        Logger.debug("[Banner] [Callback] Did record click")
         logs.append("👆 Click")
     }
 
-    func adView(_ adView: any UIView & Bidon.AdView, willPresentScreen ad: any Bidon.Ad) { }
+    func adObject(_ adObject: AdObject, didPay revenue: AdRevenue, ad: Ad) {
+        Logger.debug("[Banner] [Callback] Did pay revenue: \(revenue.revenue)")
+        logs.append("💰 Revenue: \(revenue.revenue)")
+    }
 
-    func adView(_ adView: any UIView & Bidon.AdView, didDismissScreen ad: any Bidon.Ad) { }
+    func adView(_ adView: any UIView & Bidon.AdView, willPresentScreen ad: any Bidon.Ad) {
+        Logger.debug("[Banner] [Callback] Will present screen")
+        logs.append("📲 Will present screen")
+    }
 
-    func adView(_ adView: any UIView & Bidon.AdView, willLeaveApplication ad: any Bidon.Ad) { }
+    func adView(_ adView: any UIView & Bidon.AdView, didDismissScreen ad: any Bidon.Ad) {
+        Logger.debug("[Banner] [Callback] Did dismiss screen")
+        logs.append("👋 Screen dismissed")
+    }
+
+    func adView(_ adView: any UIView & Bidon.AdView, willLeaveApplication ad: any Bidon.Ad) {
+        Logger.debug("[Banner] [Callback] Will leave application")
+        logs.append("🚪 Will leave application")
+    }
 }
 
 struct BannerAdDemoView: View {

--- a/Sandbox/Sandbox/TestScreens/BannerAdDemoView.swift
+++ b/Sandbox/Sandbox/TestScreens/BannerAdDemoView.swift
@@ -69,6 +69,7 @@ final class BannerAdController: NSObject, ObservableObject, AdViewDelegate {
         Logger.debug("[Banner] [Callback] Did fail to load with error: \(error.localizedDescription)")
         logs.append("❌ Failed to load: \(error.localizedDescription)")
         status = "Failed"
+        isAdReady = false
     }
 
     func adObject(_ adObject: AdObject, didFailToPresentAd error: any Error) {
@@ -79,16 +80,18 @@ final class BannerAdController: NSObject, ObservableObject, AdViewDelegate {
     func adObject(_ adObject: AdObject, didExpireAd ad: Ad) {
         Logger.debug("[Banner] [Callback] Did expire ad")
         logs.append("⏰ Ad expired")
+        status = "Ad Expired"
+        isAdReady = false
     }
 
     func adObject(_ adObject: AdObject, didRecordImpression ad: Ad) {
         Logger.debug("[Banner] [Callback] Did record impression")
-        logs.append("👁 Impression")
+        logs.append("👁 Impression recorded")
     }
 
     func adObject(_ adObject: AdObject, didRecordClick ad: Ad) {
         Logger.debug("[Banner] [Callback] Did record click")
-        logs.append("👆 Click")
+        logs.append("👆 Click recorded")
     }
 
     func adObject(_ adObject: AdObject, didPay revenue: AdRevenue, ad: Ad) {

--- a/Sandbox/Sandbox/TestScreens/InterstitialAdDemoView.swift
+++ b/Sandbox/Sandbox/TestScreens/InterstitialAdDemoView.swift
@@ -66,6 +66,7 @@ final class InterstitialAdController: NSObject, ObservableObject, FullscreenAdDe
         Logger.debug("[Interstitial] [Callback] Did fail to load with error: \(error.localizedDescription)")
         logs.append("❌ Failed to load: \(error.localizedDescription)")
         status = "Failed"
+        isAdReady = false
     }
 
     func adObject(_ adObject: AdObject, didFailToPresentAd error: any Error) {
@@ -76,6 +77,8 @@ final class InterstitialAdController: NSObject, ObservableObject, FullscreenAdDe
     func adObject(_ adObject: AdObject, didExpireAd ad: Ad) {
         Logger.debug("[Interstitial] [Callback] Did expire ad")
         logs.append("⏰ Ad expired")
+        status = "Ad Expired"
+        isAdReady = false
     }
 
     func adObject(_ adObject: AdObject, didRecordImpression ad: Ad) {

--- a/Sandbox/Sandbox/TestScreens/InterstitialAdDemoView.swift
+++ b/Sandbox/Sandbox/TestScreens/InterstitialAdDemoView.swift
@@ -56,22 +56,51 @@ final class InterstitialAdController: NSObject, ObservableObject, FullscreenAdDe
     // MARK: - FullscreenAdDelegate
 
     func adObject(_ adObject: AdObject, didLoadAd ad: Ad, auctionInfo: AuctionInfo) {
+        Logger.debug("[Interstitial] [Callback] Did load ad")
         logs.append("✅ Ad Loaded")
         status = "Ad Loaded"
         isAdReady = true
     }
 
     func adObject(_ adObject: AdObject, didFailToLoadAd error: any Error, auctionInfo: AuctionInfo) {
+        Logger.debug("[Interstitial] [Callback] Did fail to load with error: \(error.localizedDescription)")
         logs.append("❌ Failed to load: \(error.localizedDescription)")
         status = "Failed"
     }
 
+    func adObject(_ adObject: AdObject, didFailToPresentAd error: any Error) {
+        Logger.debug("[Interstitial] [Callback] Did fail to present with error: \(error.localizedDescription)")
+        logs.append("❌ Failed to present: \(error.localizedDescription)")
+    }
+
+    func adObject(_ adObject: AdObject, didExpireAd ad: Ad) {
+        Logger.debug("[Interstitial] [Callback] Did expire ad")
+        logs.append("⏰ Ad expired")
+    }
+
+    func adObject(_ adObject: AdObject, didRecordImpression ad: Ad) {
+        Logger.debug("[Interstitial] [Callback] Did record impression")
+        logs.append("👁 Impression recorded")
+    }
+
+    func adObject(_ adObject: AdObject, didRecordClick ad: Ad) {
+        Logger.debug("[Interstitial] [Callback] Did record click")
+        logs.append("👆 Click recorded")
+    }
+
+    func adObject(_ adObject: AdObject, didPay revenue: AdRevenue, ad: Ad) {
+        Logger.debug("[Interstitial] [Callback] Did pay revenue: \(revenue.revenue)")
+        logs.append("💰 Revenue: \(revenue.revenue)")
+    }
+
     func fullscreenAd(_ adObject: FullscreenAdObject, willPresentAd ad: Ad) {
+        Logger.debug("[Interstitial] [Callback] Will present ad")
         logs.append("📲 Will present ad")
         status = "Showing"
     }
 
     func fullscreenAd(_ adObject: FullscreenAdObject, didDismissAd ad: Ad) {
+        Logger.debug("[Interstitial] [Callback] Did dismiss ad")
         logs.append("👋 Ad dismissed")
         status = "Dismissed"
         isAdReady = false

--- a/Sandbox/Sandbox/TestScreens/RewardedAdDemoView.swift
+++ b/Sandbox/Sandbox/TestScreens/RewardedAdDemoView.swift
@@ -65,6 +65,7 @@ final class RewardedAdController: NSObject, ObservableObject, FullscreenAdDelega
         Logger.debug("[Rewarded] [Callback] Did fail to load with error: \(error.localizedDescription)")
         logs.append("❌ Failed to load: \(error.localizedDescription)")
         status = "Failed"
+        isAdReady = false
     }
 
     func adObject(_ adObject: AdObject, didFailToPresentAd error: any Error) {
@@ -75,6 +76,8 @@ final class RewardedAdController: NSObject, ObservableObject, FullscreenAdDelega
     func adObject(_ adObject: AdObject, didExpireAd ad: Ad) {
         Logger.debug("[Rewarded] [Callback] Did expire ad")
         logs.append("⏰ Ad expired")
+        status = "Ad Expired"
+        isAdReady = false
     }
 
     func adObject(_ adObject: AdObject, didRecordImpression ad: Ad) {

--- a/Sandbox/Sandbox/TestScreens/RewardedAdDemoView.swift
+++ b/Sandbox/Sandbox/TestScreens/RewardedAdDemoView.swift
@@ -55,29 +55,61 @@ final class RewardedAdController: NSObject, ObservableObject, FullscreenAdDelega
     // MARK: - FullscreenAdDelegate
 
     func adObject(_ adObject: AdObject, didLoadAd ad: Ad, auctionInfo: AuctionInfo) {
+        Logger.debug("[Rewarded] [Callback] Did load ad")
         logs.append("✅ Ad Loaded")
         status = "Ad Loaded"
         isAdReady = true
     }
 
     func adObject(_ adObject: AdObject, didFailToLoadAd error: any Error, auctionInfo: AuctionInfo) {
+        Logger.debug("[Rewarded] [Callback] Did fail to load with error: \(error.localizedDescription)")
         logs.append("❌ Failed to load: \(error.localizedDescription)")
         status = "Failed"
     }
 
+    func adObject(_ adObject: AdObject, didFailToPresentAd error: any Error) {
+        Logger.debug("[Rewarded] [Callback] Did fail to present with error: \(error.localizedDescription)")
+        logs.append("❌ Failed to present: \(error.localizedDescription)")
+    }
+
+    func adObject(_ adObject: AdObject, didExpireAd ad: Ad) {
+        Logger.debug("[Rewarded] [Callback] Did expire ad")
+        logs.append("⏰ Ad expired")
+    }
+
+    func adObject(_ adObject: AdObject, didRecordImpression ad: Ad) {
+        Logger.debug("[Rewarded] [Callback] Did record impression")
+        logs.append("👁 Impression recorded")
+    }
+
+    func adObject(_ adObject: AdObject, didRecordClick ad: Ad) {
+        Logger.debug("[Rewarded] [Callback] Did record click")
+        logs.append("👆 Click recorded")
+    }
+
+    func adObject(_ adObject: AdObject, didPay revenue: AdRevenue, ad: Ad) {
+        Logger.debug("[Rewarded] [Callback] Did pay revenue: \(revenue.revenue)")
+        logs.append("💰 Revenue: \(revenue.revenue)")
+    }
+
     func fullscreenAd(_ adObject: FullscreenAdObject, willPresentAd ad: Ad) {
+        Logger.debug("[Rewarded] [Callback] Will present ad")
         logs.append("📲 Will present ad")
         status = "Showing"
     }
 
     func fullscreenAd(_ adObject: FullscreenAdObject, didDismissAd ad: Ad) {
+        Logger.debug("[Rewarded] [Callback] Did dismiss ad")
         logs.append("👋 Ad dismissed")
         status = "Dismissed"
         isAdReady = false
     }
 
+    // MARK: - RewardedAdDelegate
+
     func rewardedAd(_ rewardedAd: any Bidon.RewardedAdObject, didRewardUser reward: any Bidon.Reward, ad: any Bidon.Ad) {
-        logs.append("👋 Reward granted")
+        Logger.debug("[Rewarded] [Callback] Did reward user with reward: \(reward.label), amount: \(reward.amount)")
+        logs.append("🎁 Reward granted: \(reward.amount) \(reward.label)")
         status = "Reward"
         isAdReady = false
     }


### PR DESCRIPTION
## Summary
Add explicit ad lifecycle callback logging to Sandbox demo screens for QA verification. Previously, the demo controllers were missing most optional delegate methods and had no console logging, making it difficult to verify that callbacks fire correctly during testing.

## Key Changes
- **InterstitialAdDemoView.swift**: Implemented all missing optional delegate callbacks (`didFailToPresent`, `didExpire`, `didRecordImpression`, `didRecordClick`, `didPay`) and added `Logger.debug()` to every callback
- **RewardedAdDemoView.swift**: Same coverage as Interstitial, plus `didRewardUser` with reward details logging
- **BannerAdDemoView.swift**: Added logging to previously empty callbacks (`willPresentScreen`, `didDismissScreen`, `willLeaveApplication`) and implemented missing ones (`didFailToPresent`, `didExpire`, `didPay`)
- **CHANGELOG.md**: Added BDN-1147 entry

## Implementation Details
- Each callback logs via `Logger.debug("[AdType] [Callback] Event description")` for Xcode console output
- Each callback also appends to the in-app `logs` array for on-screen visibility
- No changes to core SDK — all logging is in the Sandbox test app only

## Jira
BDN-1147: Add callback logging for ad lifecycle events