### PR TITLE
CI: skip Adapter Quality when latest push only changes Podfile.lock

### DIFF
--- a/.github/workflows/ci-adapter-quality.yml
+++ b/.github/workflows/ci-adapter-quality.yml
@@ -7,7 +7,51 @@ on:
   workflow_dispatch:
 
 jobs:
+  filter:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.diff.outputs.run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: diff
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+          ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+          if [[ "${ACTION:-}" != "synchronize" ]]; then
+            echo "Not a synchronize event — running quality."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -z "${BEFORE:-}" || "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
+            echo "No before SHA — running quality."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "Before SHA $BEFORE not in local clone — running quality."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CHANGED=$(git diff --name-only "$BEFORE" "$AFTER" || true)
+          echo "Files changed in latest push:"
+          echo "$CHANGED"
+          REMAINING=$(echo "$CHANGED" | grep -v '^Podfile\.lock$' || true)
+          if [[ -z "$REMAINING" ]]; then
+            echo "Latest push only modified Podfile.lock — skipping quality."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Non-Podfile.lock changes detected — running quality."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   quality:
+    needs: filter
+    if: ${{ needs.filter.outputs.run == 'true' }}
     uses: bidon-io/dependamachine/.github/workflows/ios-ci-adapter-quality.yml@main
     with:
       workspace: BidOn.xcworkspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Develop
 
+- CI: skip CI Adapter Quality re-run when latest push only modifies Podfile.lock (merge-conflict fixes on `chore/pod-*` PRs)
+
 ## Fixes
 - APDM-2195 Fix SIGABRT in AdaptersInitializator when adapter init main-queue dispatch races the timeout watchdog
 - APDM-2195 Fix banner crash from BannerAdManager.state data race between auction completion and notifyLoss by serializing state access through an NSLock


### PR DESCRIPTION
## Summary
On `chore/pod-*` PRs, fixing a Podfile.lock merge conflict (typically via the GitHub "resolve conflicts" UI) currently re-triggers the full **CI Adapter Quality** pipeline — build, tests, deprecation scan, plus the downstream `Automation post pods update` and `claude-code` chain — even though no source changed.

This PR adds a preflight `filter` job to `ci-adapter-quality.yml` that diffs `github.event.before` ↔ `github.event.after` on `synchronize` events. If the only file in the latest push is `Podfile.lock`, the heavy reusable workflow is skipped (`needs.filter.outputs.run == 'true'` gate). All other triggers — `opened`, `workflow_dispatch`, multi-file pushes — keep running quality unchanged.

`develop` has no required-checks branch protection, so a skipped `quality` job does not block merge.

## Test plan
- [ ] Open a fresh `chore/pod-*` PR — `quality` runs on `opened` (BEFORE is zero SHA → `run=true`)
- [ ] Push a Podfile.lock-only commit to an existing PR — `filter` logs "Latest push only modified Podfile.lock — skipping quality", `quality` is skipped
- [ ] Push a commit touching `Adapters/**` or `Podfile` — `filter` logs "Non-Podfile.lock changes detected", `quality` runs as before
- [ ] Manual `workflow_dispatch` — `quality` runs (action != synchronize)